### PR TITLE
Support `@summary` tag.

### DIFF
--- a/ERD.md
+++ b/ERD.md
@@ -10,6 +10,7 @@
 - [Coupons](#Coupons)
 - [Coins](#Coins)
 - [Inquiries](#Inquiries)
+- [default](#default)
 
 ## Articles
 ```mermaid
@@ -2438,3 +2439,32 @@ the person who wrote the inquiry.
   - `id`: PK + FK
   - `shopping_seller_id`: Writer seller's [shopping_sellers.id](#shopping_sellers)
   - `shopping_customer_id`: Writer customer's [shopping_customers.id](#shopping_customers)
+
+
+## default
+```mermaid
+erDiagram
+mv_cache_times {
+    String id PK
+    String schema
+    String table
+    String key
+    DateTime value
+}
+```
+
+### `mv_cache_times`
+Table for caching.
+
+**Properties**
+  - `id`: Primary Key.
+  - `schema`: Target schema.
+  - `table`
+    > Target table.
+    > 
+    > Database table name.
+  - `key`
+    > Identifier of target record.
+    > 
+    > Even when key type is not string, it must be converted to the string value.
+  - `value`: The time when the cache data being archived.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-markdown",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Prisma Markdown documents generator including ERD diagrams and comment descriptions",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/schema.prisma
+++ b/schema.prisma
@@ -3487,3 +3487,34 @@ model shopping_sale_snapshot_inquiry_comments {
     seller   shopping_sellers?    @relation(fields: [shopping_seller_id], references: [id], onDelete: Cascade)
     customer shopping_customers?  @relation(fields: [shopping_customer_id], references: [id], onDelete: Cascade)
 }
+
+/// @summary Table for caching.
+///
+/// @author Samchon
+model mv_cache_times {
+    //----
+    // COLUMNS
+    //----
+    /// @summary Primary Key.
+    ///
+    /// @Format uuid
+    id String @id @db.Uuid
+
+    /// @summary Target schema.
+    schema String @db.VarChar
+
+    /// @summary Target table.
+    ///
+    /// Database table name.
+    table String @db.VarChar
+
+    /// @summary Identifier of target record.
+    ///
+    /// Even when key type is not string, it must be converted to the string value.
+    key String @db.VarChar
+
+    /// The time when the cache data being archived.
+    value DateTime @db.Timestamptz
+
+    @@unique([schema, table, key])
+}

--- a/src/utils/PrismaUtil.ts
+++ b/src/utils/PrismaUtil.ts
@@ -1,0 +1,24 @@
+import { DMMF } from "@prisma/generator-helper";
+
+export namespace PrismaUtil {
+    export const tagValues =
+        (kind: string) =>
+        (model: DMMF.Model | DMMF.Field): string[] => {
+            if (!model.documentation?.length) return [];
+
+            const output: string[] = [];
+            const splitted: string[] = model.documentation
+                .split("\r\n")
+                .join("\n")
+                .split("\n");
+            for (const line of splitted) {
+                const first: number = line.indexOf(`@${kind} `);
+                if (first === -1) continue;
+
+                output.push(line.slice(first + kind.length + 2).trim());
+            }
+            return output
+                .map((str) => str.trim())
+                .filter((str) => !!str.length);
+        };
+}

--- a/src/writers/MarkdownWriter.ts
+++ b/src/writers/MarkdownWriter.ts
@@ -2,6 +2,7 @@ import { DMMF } from "@prisma/generator-helper";
 import { MermaidWriter } from "./MermaidWriter";
 import { DescriptionWriter } from "./DescriptionWriter";
 import { MapUtil } from "../utils/MapUtil";
+import { PrismaUtil } from "../utils/PrismaUtil";
 
 export namespace MarkdownWriter {
     export const write = (
@@ -76,27 +77,13 @@ export namespace MarkdownWriter {
 
     const takeTags =
         (kind: "namespace" | "describe" | "erd") =>
-        (model: DMMF.Model): string[] => {
-            if (!model.documentation?.length) return [];
-
-            const output: Set<string> = new Set();
-            const splitted: string[] = model.documentation
-                .split("\r\n")
-                .join("\n")
-                .split("\n");
-            for (const line of splitted) {
-                const first: number = line.indexOf(`@${kind} `);
-                if (first === -1) continue;
-
-                const last: number = line.indexOf(" ", kind.length + 2);
-                output.add(
-                    last === -1
-                        ? line.slice(first + kind.length + 2)
-                        : line.slice(first + kind.length + 2, last),
-                );
-            }
-            return [...output];
-        };
+        (model: DMMF.Model): string[] => [
+            ...new Set(
+                PrismaUtil.tagValues(kind)(model).map(
+                    (str) => str.split(" ")[0],
+                ),
+            ),
+        ];
 
     const isHidden = (model: DMMF.Model): boolean =>
         model.documentation?.includes("@hidden") ?? false;


### PR DESCRIPTION
Requested by someone who prefers `JsDoc` styled tags.

```prisma
/// @summary Table for caching.
///
/// @author Samchon
model mv_cache_times {
    //----
    // COLUMNS
    //----
    /// @summary Primary Key.
    ///
    /// @Format uuid
    id String @id @db.Uuid

    /// @summary Target schema.
    schema String @db.VarChar

    /// @summary Target table.
    ///
    /// Database table name.
    table String @db.VarChar

    /// @summary Identifier of target record.
    ///
    /// Even when key type is not string, it must be converted to the string value.
    key String @db.VarChar

    /// The time when the cache data being archived.
    value DateTime @db.Timestamptz

    @@unique([schema, table, key])
}
```