### PR TITLE
feat(suggestion): add 'separated' generation option

### DIFF
--- a/src/writers/DescriptionWriter.ts
+++ b/src/writers/DescriptionWriter.ts
@@ -2,14 +2,20 @@ import { DMMF } from "@prisma/client/runtime/library";
 import { PrismaUtil } from "../utils/PrismaUtil";
 
 export namespace DescriptionWriter {
-    export const table = (model: DMMF.Model): string => {
+    export const table = (
+        model: DMMF.Model,
+        config?: Record<string, string | string[] | undefined>,
+    ): string => {
         const description: string = writeDescription(model);
+        const separated: boolean = config?.separated === "true";
+
         return [
             `### \`${model.dbName ?? model.name}\``,
             ...(description.length ? [description] : []),
             "",
             "**Properties**",
             ...model.fields.filter((f) => f.kind !== "object").map(writeField),
+            ...(separated ? ["---"] : []),
         ].join("\n");
     };
 

--- a/src/writers/MarkdownWriter.ts
+++ b/src/writers/MarkdownWriter.ts
@@ -65,13 +65,15 @@ export namespace MarkdownWriter {
             "",
             ...[...dict.keys()].map((name) => `- [${name}](#${name})`),
         ].join("\n");
+        const separated: boolean = config?.separated === "true";
+
         return (
             preface +
             "\n\n" +
             [...dict.values()]
                 .filter((s) => !!s.descriptions.size)
-                .map(writeChapter)
-                .join("\n\n\n")
+                .map((chapter) => writeChapter(chapter, config))
+                .join(separated ? "\n\n<br/>\n\n" : "\n\n\n")
         );
     };
 
@@ -88,12 +90,17 @@ export namespace MarkdownWriter {
     const isHidden = (model: DMMF.Model): boolean =>
         model.documentation?.includes("@hidden") ?? false;
 
-    const writeChapter = (chapter: IChapter): string =>
+    const writeChapter = (
+        chapter: IChapter,
+        config?: Record<string, string | string[] | undefined>,
+    ): string =>
         [
             `## ${chapter.name}`,
             MermaidWriter.write([...chapter.diagrams]),
             "",
-            [...chapter.descriptions].map(DescriptionWriter.table).join("\n\n"),
+            [...chapter.descriptions]
+                .map((model) => DescriptionWriter.table(model, config))
+                .join("\n\n"),
         ].join("\n");
 }
 


### PR DESCRIPTION
## Suggestion

- A custom option for adding separator between **chapters** and **descriptions**

Personally I've been writing markdowns by separating paragraphs with sections. And this actually improved the readability and so I think this could be a helpful option to users.

<br/>   

## How it can be used

```prisma
generator markdown {
    provider = "node ./lib/executable/markdown"
    title    = "Shopping Mall"
    separated = true // or "true" since config records are regarded as "string", defaults to false
}
```

Just by setting custom option `separated` to prisma generator, users can turn on/off this feature.


<br/>   

## Result

[Modified ERD.md](https://github.com/SeiwonPark/prisma-markdown/blob/example/ERD.md)

`##` Sections are separated by `<br/>` and each `###` properties are separated by `---`(horizontal line)