### PR TITLE
Optional cardinality in the 1 side.

### DIFF
--- a/ERD.md
+++ b/ERD.md
@@ -455,12 +455,12 @@ erDiagram
   String special_note "nullable"
   DateTime created_at
 }
-"shopping_customers" }o--|| "shopping_members" : member
-"shopping_customers" }o--|| "shopping_external_users" : external_user
-"shopping_customers" }o--|| "shopping_citizens" : citizen
-"shopping_external_users" }o--|| "shopping_citizens" : citizen
-"shopping_members" }o--|| "shopping_citizens" : citizen
-"shopping_member_emails" }o--|| "shopping_members" : member
+"shopping_customers" }|--o| "shopping_members" : member
+"shopping_customers" }|--o| "shopping_external_users" : external_user
+"shopping_customers" }|--o| "shopping_citizens" : citizen
+"shopping_external_users" }o--o| "shopping_citizens" : citizen
+"shopping_members" }o--o| "shopping_citizens" : citizen
+"shopping_member_emails" }|--|| "shopping_members" : member
 "shopping_sellers" |o--|| "shopping_members" : member
 "shopping_administrators" |o--|| "shopping_members" : member
 ```
@@ -1281,7 +1281,7 @@ erDiagram
 "shopping_cart_commodity_stocks" }o--|| "shopping_sale_snapshot_unit_stocks" : stock
 "shopping_cart_commodity_stock_choices" }o--|| "shopping_cart_commodity_stocks" : stock
 "shopping_cart_commodity_stock_choices" }o--|| "shopping_sale_snapshot_unit_options" : option
-"shopping_cart_commodity_stock_choices" }o--|| "shopping_sale_snapshot_unit_option_candidates" : candidate
+"shopping_cart_commodity_stock_choices" }o--o| "shopping_sale_snapshot_unit_option_candidates" : candidate
 "shopping_sale_snapshot_units" }o--|| "shopping_sale_snapshots" : snapshot
 "shopping_sale_snapshot_unit_options" }o--|| "shopping_sale_snapshot_units" : unit
 "shopping_sale_snapshot_unit_option_candidates" }o--|| "shopping_sale_snapshot_unit_options" : option
@@ -1512,7 +1512,7 @@ erDiagram
   Int quantity
   Int sequence
 }
-"shopping_orders" }o--|| "shopping_addresses" : address
+"shopping_orders" }o--o| "shopping_addresses" : address
 "shopping_order_goods" }o--|| "shopping_orders" : order
 "shopping_order_goods" }o--|| "shopping_cart_commodities" : commodity
 "shopping_order_publishes" |o--|| "shopping_orders" : order
@@ -1836,7 +1836,7 @@ erDiagram
 "shopping_coupon_sale_criterias" |o--|| "shopping_coupon_criterias" : base
 "shopping_coupon_funnel_criterias" |o--|| "shopping_coupon_criterias" : base
 "shopping_coupon_tickets" }o--|| "shopping_coupons" : coupon
-"shopping_coupon_tickets" |o--|| "shopping_coupon_disposables" : disposable
+"shopping_coupon_tickets" |o--o| "shopping_coupon_disposables" : disposable
 "shopping_coupon_ticket_payments" |o--|| "shopping_coupon_tickets" : ticket
 "shopping_coupon_disposables" }o--|| "shopping_coupons" : coupon
 ```
@@ -2288,7 +2288,7 @@ erDiagram
 "shopping_mileage_donations" }o--|| "shopping_citizens" : citizen
 "shopping_mileage_histories" }o--|| "shopping_mileages" : mileage
 "shopping_mileage_histories" }o--|| "shopping_citizens" : citizen
-"shopping_customers" }o--|| "shopping_citizens" : citizen
+"shopping_customers" }|--o| "shopping_citizens" : citizen
 ```
 
 ### `shopping_deposits`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-markdown",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Prisma Markdown documents generator including ERD diagrams and comment descriptions",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/schema.prisma
+++ b/schema.prisma
@@ -798,9 +798,11 @@ model shopping_external_users {
   //----
   // RELATIONS
   //----
-  channel            shopping_channels    @relation(fields: [shopping_channel_id], references: [id], onDelete: Cascade)
-  citizen            shopping_citizens?   @relation(fields: [shopping_citizen_id], references: [id], onDelete: Cascade)
-  shopping_customers shopping_customers[]
+  channel shopping_channels  @relation(fields: [shopping_channel_id], references: [id], onDelete: Cascade)
+  citizen shopping_citizens? @relation(fields: [shopping_citizen_id], references: [id], onDelete: Cascade)
+
+  /// @minItems 1
+  customers shopping_customers[]
 
   @@unique([shopping_channel_id, application, uid])
   @@unique([shopping_channel_id, application, nickname])
@@ -866,6 +868,7 @@ model shopping_citizens {
   //----
   channel shopping_channels? @relation(fields: [shopping_channel_id], references: [id], onDelete: Cascade)
 
+  /// @minItems 1
   customers                  shopping_customers[]
   members                    shopping_members[]
   deposit_histories          shopping_deposit_histories[]
@@ -947,9 +950,13 @@ model shopping_members {
   citizen shopping_citizens? @relation(fields: [shopping_citizen_id], references: [id], onDelete: Cascade)
 
   /// List of customer records (connections).
+  ///
+  /// @minItems 1
   customers shopping_customers[]
 
   /// List of email addresses.
+  ///
+  /// @minItems 1
   emails shopping_member_emails[]
 
   of_seller shopping_sellers?

--- a/src/writers/MarkdownWriter.ts
+++ b/src/writers/MarkdownWriter.ts
@@ -244,7 +244,7 @@ export namespace MarkdownWriter {
         primaryKey: null,
         documentation: description.join("\n"),
       };
-      x.fields.push({
+      (x.fields as DMMF.Field[]).push({
         kind: "object",
         name,
         type: name,
@@ -256,7 +256,7 @@ export namespace MarkdownWriter {
         hasDefaultValue: false,
         relationToFields: ["A"],
       });
-      y.fields.push({
+      (y.fields as DMMF.Field[]).push({
         kind: "object",
         name,
         type: name,

--- a/src/writers/MermaidWriter.ts
+++ b/src/writers/MermaidWriter.ts
@@ -69,23 +69,23 @@ export namespace MermaidWriter {
       const oneToOne: boolean = scalar.isId || scalar.isUnique;
       const arrow: string = [
         oneToOne ? "|" : "}",
-        !scalar.isRequired ||
-        (oneToOne &&
-          props.group.some(
-            (m) =>
-              m.name === field.type &&
-              m.fields.some(
-                (f) => f.relationName === field.relationName && !f.isRequired,
-              ),
-          ))
+        oneToOne &&
+        props.group.some(
+          (m) =>
+            m.name === field.type &&
+            m.fields.some(
+              (f) => f.relationName === field.relationName && !f.isRequired,
+            ),
+        )
           ? "o"
           : isMandatoryMany({ model: props.model, field, target })
             ? "|"
             : "o",
         "--",
-        props.model === target ? "o" : "|",
+        scalar.isRequired ? "|" : "o",
         "|",
       ].join("");
+
       return [
         JSON.stringify(props.model.dbName ?? props.model.name),
         arrow,

--- a/test/drive.md
+++ b/test/drive.md
@@ -104,11 +104,11 @@ erDiagram
   String role
   DateTime created_at
 }
-"drive_customers" }o--|| "drive_members" : member
-"drive_customers" }o--|| "drive_external_users" : external_user
-"drive_customers" }o--|| "drive_citizens" : citizen
-"drive_members" }o--|| "drive_accounts" : account
-"drive_members" }o--|| "drive_citizens" : citizen
+"drive_customers" }o--o| "drive_members" : member
+"drive_customers" }o--o| "drive_external_users" : external_user
+"drive_customers" }o--o| "drive_citizens" : citizen
+"drive_members" }o--o| "drive_accounts" : account
+"drive_members" }o--o| "drive_citizens" : citizen
 "drive_member_emails" }o--|| "drive_members" : member
 "drive_enterprises" }o--|| "drive_accounts" : account
 "drive_enterprise_employees" }o--|| "drive_enterprises" : enterprise
@@ -487,7 +487,7 @@ erDiagram
   DateTime created_at
 }
 "drive_repository_buckets" }o--|| "drive_repositories" : repository
-"drive_repository_buckets" }o--|| "drive_repository_folders" : folder
+"drive_repository_buckets" }o--o| "drive_repository_folders" : folder
 "drive_repository_folders" |o--|| "drive_repository_buckets" : base
 "drive_repository_files" |o--|| "drive_repository_buckets" : base
 "drive_repository_shortcuts" |o--|| "drive_repository_buckets" : base


### PR DESCRIPTION
```mermaid
erDiagram
"one" |o--|{ "many" : special
```

When one-to-many relationship is optional in the one side, `prisma-markdown` could not express it in the diagram. Also, if one side is optional, but many side is mandatory, `prisma-markdown` also could not express it exactly, either.

This PR fixes the bug, so that one side optional cardinality can be exactly represented.