### PR TITLE
Fix `occured` -> `occurred` typo (2 occurrences) in ERD.md

### DIFF
--- a/ERD.md
+++ b/ERD.md
@@ -2439,7 +2439,7 @@ Properties as follows:
 - `id`: Primary Key.
 - `shopping_deposit_id`: Belonged metadata's [shopping_deposits.id](#shopping_deposits)
 - `shopping_citizen_id`: Belonged citizen's [shopping_citizens.id](#shopping_citizens)
-- `source_id`: The source record occured deposit/outcome.
+- `source_id`: The source record occurred deposit/outcome.
 - `value`
   > Income/outcome amount of deposit.
   >
@@ -2574,7 +2574,7 @@ Properties as follows:
 - `id`: Primary Key.
 - `shopping_mileage_id`: Belonged metadata's [shopping_mileages.id](#shopping_mileages)
 - `shopping_citizen_id`: Belonged citizen's [shopping_citizens.id](#shopping_citizens)
-- `source_id`: The source record occured income/outcome.
+- `source_id`: The source record occurred income/outcome.
 - `value`
   > Income/outcome amount of mileage.
   >


### PR DESCRIPTION
Lines 2442 and 2577 of ERD.md both have `occured` (should be `occurred` — double r) in source_id field descriptions for deposit/outcome and income/outcome records.